### PR TITLE
Fixes

### DIFF
--- a/scp035/Config.cs
+++ b/scp035/Config.cs
@@ -12,7 +12,7 @@ namespace scp035
 		[Description("The items that are possible to spawn as SCP-035.")]
 		public List<int> PossibleItems { get; set; } = new List<int>() { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 19, 20, 21, 23, 24, 25, 26, 27, 30, 33, 34 };
 
-		[Description("The health fo SCP-035")]
+		[Description("The health for SCP-035")]
 		public int Health { get; set; } = 300;
 		[Description("The amount of infected items on the map at any given time.")]
 		public int InfectedItemCount { get; set; } = 1;

--- a/scp035/Harmony/Scp096Patches.cs
+++ b/scp035/Harmony/Scp096Patches.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HarmonyLib;
+using System.Reflection.Emit;
+using static HarmonyLib.AccessTools;
+using Exiled.API.Features;
+
+namespace scp035.Harmony
+{
+	[HarmonyPatch(typeof(PlayableScps.Scp096), nameof(PlayableScps.Scp096.OnDamage))]
+	static class Scp096Patches
+	{
+		public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+		{
+			var newInstructions = instructions.ToList();
+
+			var returnLabel = newInstructions.First(i => i.opcode == OpCodes.Brfalse_S).operand;
+			var continueLabel = generator.DefineLabel();
+			var firstOffset = newInstructions.FindIndex(i => i.opcode == OpCodes.Ldloc_0) + 1;
+
+			var player = generator.DeclareLocal(typeof(Player));
+			var scp035 = generator.DeclareLocal(typeof(Player));
+
+			newInstructions.InsertRange(firstOffset, new CodeInstruction[] 
+			{
+				new CodeInstruction(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(UnityEngine.GameObject) })),
+				new CodeInstruction(OpCodes.Stloc_1, player.LocalIndex),
+				new CodeInstruction(OpCodes.Call, Method(typeof(API.Scp035Data), nameof(API.Scp035Data.GetScp035))),
+				new CodeInstruction(OpCodes.Stloc_2, scp035.LocalIndex),
+				new CodeInstruction(OpCodes.Ldloc_0)
+			});
+
+			var secondOffset = newInstructions.FindIndex(i => i.opcode == OpCodes.Ldnull) + 3;
+
+			newInstructions.InsertRange(secondOffset, new CodeInstruction[]
+			{
+				new CodeInstruction(OpCodes.Ldloc_2),
+				new CodeInstruction(OpCodes.Brfalse_S, continueLabel),
+				new CodeInstruction(OpCodes.Ldloc_1),
+				new CodeInstruction(OpCodes.Brfalse_S, continueLabel),
+				new CodeInstruction(OpCodes.Ldloc_2),
+				new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(Player), nameof(Player.Id))),
+				new CodeInstruction(OpCodes.Ldloc_1),
+				new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(Player), nameof(Player.Id))),
+				new CodeInstruction(OpCodes.Beq_S, returnLabel)
+			});
+
+			newInstructions[secondOffset + 9].labels.Add(continueLabel);
+
+			foreach (var code in newInstructions)
+				yield return code;
+		}
+	}
+}

--- a/scp035/Logic.cs
+++ b/scp035/Logic.cs
@@ -75,7 +75,7 @@ namespace scp035
 				{
 					Vector3 pos = player.Position;
 					p035.ChangeRole(player.Role, true);
-					p035.Position = pos;
+					Timing.CallDelayed(0.5f, () => p035.Position = pos);
 
 					foreach (Inventory.SyncItemInfo item in player.Inventory.items) p035.Inventory.AddNewItem(item.id);
 				}
@@ -95,7 +95,7 @@ namespace scp035
 				isHidden = true;
 				p035.BadgeHidden = false;
 			}
-			player.ReferenceHub.nicknameSync.ShownPlayerInfo &= ~PlayerInfoArea.Role;
+			p035.ReferenceHub.nicknameSync.ShownPlayerInfo &= ~PlayerInfoArea.Role;
 			p035.CustomPlayerInfo = "<color=#FF0000>SCP-035</color>";
 
 			if (!Scp173.TurnedPlayers.Contains(p035)) Scp173.TurnedPlayers.Add(p035);


### PR DESCRIPTION
Scp035 can no longer become a target of 035 by shooting them

Scp035's position should now be overridden in all cases (In a game I played 035 spawned at default spawn, so I added delay)

Fixed an NRE that was thrown because the wrong variable was used.